### PR TITLE
Add FT sensor plugin files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(hrim_sensor_imu_msgs REQUIRED)
 find_package(hrim_sensor_lidar_msgs REQUIRED)
 find_package(hrim_sensor_rangefinder_msgs REQUIRED)
 find_package(hrim_sensor_3dcameratof_msgs REQUIRED)
+find_package(hrim_sensor_forcetorque_msgs REQUIRED)
 find_package(hrim_composite_arm_msgs REQUIRED)
 find_package(hrim_composite_mobilebase_msgs REQUIRED)
 find_package(tf2 REQUIRED)
@@ -39,6 +40,7 @@ include_directories(include
   ${hrim_sensor_lidar_msgs_INCLUDE_DIRS}
   ${hrim_sensor_rangefinder_msgs_INCLUDE_DIRS}
   ${hrim_sensor_3dcameratof_msgs_INCLUDE_DIRS}
+  ${hrim_sensor_forcetorque_msgs_INCLUDE_DIRS}
   ${hrim_composite_arm_msgs_INCLUDE_DIRS}
   ${hrim_composite_mobilebase_msgs_INCLUDE_DIRS}
   ${tf2_ros_INCLUDE_DIRS}
@@ -99,6 +101,17 @@ ament_target_dependencies(gazebo_hrim_imu_sensor
 )
 ament_export_libraries(gazebo_hrim_imu_sensor)
 
+# gazebo_hrim_ft_sensor
+add_library(gazebo_hrim_ft_sensor SHARED
+  src/gazebo_hrim_ft_sensor.cpp
+)
+ament_target_dependencies(gazebo_hrim_ft_sensor
+  "gazebo_ros"
+  "hrim_sensor_forcetorque_msgs"
+  "gazebo_dev"
+)
+ament_export_libraries(gazebo_hrim_ft_sensor)
+
 # gazebo_hrim_ray_sensor
 add_library(gazebo_hrim_ray_sensor SHARED
   src/gazebo_hrim_ray_sensor.cpp
@@ -144,6 +157,7 @@ install(TARGETS
     gazebo_hrim_camera
     gazebo_hrim_force
     gazebo_hrim_imu_sensor
+    gazebo_hrim_ft_sensor
     gazebo_hrim_ray_sensor
     gazebo_hrim_joint_state_publisher
     gazebo_hrim_diff_drive

--- a/include/gazebo_hrim_plugins/gazebo_hrim_ft_sensor.hpp
+++ b/include/gazebo_hrim_plugins/gazebo_hrim_ft_sensor.hpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2013, Markus Bader <markus.bader@tuwien.ac.at>
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the company nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GAZEBO_HRIM_PLUGINS__GAZEBO_ROS_FT_SENSOR_HPP_
+#define GAZEBO_HRIM_PLUGINS__GAZEBO_ROS_FT_SENSOR_HPP_
+
+#include <gazebo/common/Plugin.hh>
+
+#include <memory>
+
+namespace gazebo_hrim_plugins
+{
+class GazeboRosFTSensorPrivate;
+
+/// Publish the state of a joint child's force and torque in the simulation to a given ROS topic.
+/**
+
+  Valid joint types are limited to:
+  - revolute
+  - prismatic
+  - fixed
+
+  Example Usage:
+  \code{.xml}
+  <plugin name="my_ft"
+    filename="libgazebo_hrim_ft_sensor.so">
+    <ros>
+      <namespace>/demo</namespace>
+      <argument>~/out:=reading</argument>
+    </ros>
+    <update_rate>100</update_rate>
+    <joint_name>pendulum</joint_name>
+  </plugin>
+  \endcode
+
+  <provide_feedback> must be set to true on the selected joint:
+  \code{.xml}
+  <joint ...>
+    ...
+    <physics>
+      <provide_feedback>true</provide_feedback>
+    </physics>
+  </joint>
+  \endcode
+*/
+class GazeboRosFTSensor : public gazebo::ModelPlugin
+{
+public:
+  /// Constructor
+  GazeboRosFTSensor();
+
+  /// Destructor
+  ~GazeboRosFTSensor();
+
+protected:
+  // Documentation inherited
+  void Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf) override;
+
+private:
+  /// Callback to be called at every simulation iteration.
+  /// Private data pointer
+  std::unique_ptr<GazeboRosFTSensorPrivate> impl_;
+};
+}  // namespace gazebo_plugins
+#endif  // GAZEBO_PLUGINS__GAZEBO_ROS_FT_SENSOR_HPP_

--- a/src/gazebo_hrim_ft_sensor.cpp
+++ b/src/gazebo_hrim_ft_sensor.cpp
@@ -1,0 +1,200 @@
+// Copyright (c) 2013, Markus Bader <markus.bader@tuwien.ac.at>
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the company nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gazebo/common/Events.hh>
+#include <gazebo/common/Time.hh>
+#include <gazebo/physics/Joint.hh>
+#include <gazebo/physics/Link.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo_hrim_plugins/gazebo_hrim_ft_sensor.hpp>
+#include <gazebo_ros/node.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <hrim_sensor_forcetorque_msgs/msg/force_torque.hpp>
+#include <hrim_sensor_forcetorque_msgs/msg/specs_force_axis.hpp>
+#include <hrim_sensor_forcetorque_msgs/msg/specs_torque_axis.hpp>
+
+#include <memory>
+#include <string>
+
+namespace gazebo_hrim_plugins
+{
+class GazeboRosFTSensorPrivate
+{
+public:
+  /// Callback to be called at every simulation iteration.
+  /// \param[in] info Updated simulation info.
+  void OnUpdate(const gazebo::common::UpdateInfo & info);
+
+  /// A pointer to the GazeboROS node.
+  gazebo_ros::Node::SharedPtr ros_node_;
+
+  /// ForceTorque publisher.
+  rclcpp::Publisher<hrim_sensor_forcetorque_msgs::msg::ForceTorque>::SharedPtr pub_;
+
+  /// ForceTorque message to be published
+  std::shared_ptr<hrim_sensor_forcetorque_msgs::msg::ForceTorque> msg_;
+
+  /// Joint being tracked.
+  gazebo::physics::JointPtr joint_;
+
+  /// Period in seconds
+  double update_period_;
+
+  /// Keep last time an update was published
+  gazebo::common::Time last_update_time_;
+
+  /// Pointer to the update event connection.
+  gazebo::event::ConnectionPtr update_connection_;
+};
+
+GazeboRosFTSensor::GazeboRosFTSensor()
+: impl_(std::make_unique<GazeboRosFTSensorPrivate>())
+{
+}
+
+GazeboRosFTSensor::~GazeboRosFTSensor()
+{
+}
+
+void GazeboRosFTSensor::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
+{
+  // ROS node
+  impl_->ros_node_ = gazebo_ros::Node::Get(sdf);
+
+  // Joint
+  if (!sdf->HasElement("joint_name")) {
+    RCLCPP_ERROR(impl_->ros_node_->get_logger(), "Plugin missing <joint_name>");
+    impl_->ros_node_.reset();
+    return;
+  }
+
+  impl_->joint_ = NULL;
+
+  sdf::ElementPtr joint_elem = sdf->GetElement("joint_name");
+
+  auto joint_name = joint_elem->Get<std::string>();
+
+  auto joint = model->GetJoint(joint_name);
+  if (!joint) {
+    RCLCPP_ERROR(impl_->ros_node_->get_logger(), "Joint %s does not exist!", joint_name.c_str());
+  } else {
+    impl_->joint_ = joint;
+    RCLCPP_INFO(impl_->ros_node_->get_logger(), "Going to publish force & torque of child of joint [%s]",
+      joint_name.c_str() );
+  }
+
+  joint_elem = joint_elem->GetNextElement("joint_name");
+
+  if (!impl_->joint_) {
+    RCLCPP_ERROR(impl_->ros_node_->get_logger(), "No joint found.");
+    impl_->ros_node_.reset();
+    return;
+  }
+
+  // Update rate
+  double update_rate = 100.0;
+  if (!sdf->HasElement("update_rate")) {
+    RCLCPP_INFO(impl_->ros_node_->get_logger(), "Missing <update_rate>, defaults to %f",
+      update_rate);
+  } else {
+    update_rate = sdf->GetElement("update_rate")->Get<double>();
+  }
+
+  if (update_rate > 0.0) {
+    impl_->update_period_ = 1.0 / update_rate;
+  } else {
+    impl_->update_period_ = 0.0;
+  }
+
+  impl_->last_update_time_ = model->GetWorld()->SimTime();
+
+  // Initialize message
+  impl_->msg_ = std::make_shared<hrim_sensor_forcetorque_msgs::msg::ForceTorque>();
+
+  // Fill message structure
+  impl_->msg_->header.frame_id = impl_->joint_->GetChild()->GetName().c_str();
+  impl_->msg_->axis_forces[0].axis = hrim_sensor_forcetorque_msgs::msg::SpecsForceAxis::FORCE_AXIS_X;
+  impl_->msg_->axis_forces[1].axis = hrim_sensor_forcetorque_msgs::msg::SpecsForceAxis::FORCE_AXIS_Y;
+  impl_->msg_->axis_forces[2].axis = hrim_sensor_forcetorque_msgs::msg::SpecsForceAxis::FORCE_AXIS_Z;
+  impl_->msg_->axis_torques[0].axis = hrim_sensor_forcetorque_msgs::msg::SpecsTorqueAxis::TORQUE_AXIS_X;
+  impl_->msg_->axis_torques[1].axis = hrim_sensor_forcetorque_msgs::msg::SpecsTorqueAxis::TORQUE_AXIS_Y;
+  impl_->msg_->axis_torques[2].axis = hrim_sensor_forcetorque_msgs::msg::SpecsTorqueAxis::TORQUE_AXIS_Z;
+
+  // ForceTorque publisher
+  impl_->pub_ = impl_->ros_node_->create_publisher<hrim_sensor_forcetorque_msgs::msg::ForceTorque>("~/out");
+
+  // Callback on every iteration
+  impl_->update_connection_ = gazebo::event::Events::ConnectWorldUpdateBegin(
+    std::bind(&GazeboRosFTSensorPrivate::OnUpdate, impl_.get(), std::placeholders::_1));
+}
+
+void GazeboRosFTSensorPrivate::OnUpdate(const gazebo::common::UpdateInfo & info)
+{
+  gazebo::common::Time current_time = info.simTime;
+
+  // If the world is reset, for example
+  if (current_time < last_update_time_) {
+    RCLCPP_INFO(ros_node_->get_logger(), "Negative sim time difference detected.");
+    last_update_time_ = current_time;
+  }
+
+  // Check period
+  double seconds_since_last_update = (current_time - last_update_time_).Double();
+
+  if (seconds_since_last_update < update_period_) {
+    return;
+  }
+
+  // Get wrench data
+  auto wrench = joint_->GetForceTorque(1);
+
+  // Populate message
+  msg_->header.stamp.sec = int(current_time.sec);
+  msg_->header.stamp.nanosec = uint(current_time.nsec);
+  msg_->axis_forces[0].force = wrench.body2Force.X();
+  msg_->axis_forces[1].force = wrench.body2Force.Y();
+  msg_->axis_forces[2].force = wrench.body2Force.Z();
+  msg_->axis_torques[0].torque = wrench.body2Torque.X();
+  msg_->axis_torques[1].torque = wrench.body2Torque.Y();
+  msg_->axis_torques[2].torque = wrench.body2Torque.Z();
+
+  // Publish
+  pub_->publish(msg_);
+
+  // Update time
+  last_update_time_ = current_time;
+}
+
+GZ_REGISTER_MODEL_PLUGIN(GazeboRosFTSensor)
+}  // namespace gazebo_plugins

--- a/worlds/gazebo_hrim_ft_sensor.world
+++ b/worlds/gazebo_hrim_ft_sensor.world
@@ -1,0 +1,143 @@
+<?xml version="1.0"?>
+<!--
+  Gazebo HRIM ft sensor plugin demo
+-->
+<sdf version="1.6">
+  <world name="default">
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <model name="pendulum_with_base">
+      <link name="base">
+        <inertial>
+          <mass>100</mass>
+        </inertial>
+        <visual name="vis_plate_on_ground">
+          <pose>0 0 0.01 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.8</radius>
+              <length>0.02</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+        <visual name="vis_pole">
+          <pose>-0.275 0 1.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.2 2.2</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+        <collision name="col_plate_on_ground">
+          <pose>0 0 0.01 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.8</radius>
+              <length>0.02</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <collision name="col_pole">
+          <pose>-0.275 0 1.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.2 0.2 2.2</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <!-- pendulum, length 1, IC -90 degrees -->
+      <link name="pendulum">
+        <pose>0 0 2.1 -1.5708 0 0</pose>
+        <self_collide>0</self_collide>
+        <inertial>
+          <pose>0 0 0.5 0 0 0</pose>
+        </inertial>
+        <visual name="vis_upper_joint">
+          <pose>-0.05 0 0 0 1.5708 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+        <visual name="vis_cylinder">
+          <pose>0 0 0.5 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.9</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+        <collision name="col_upper_joint">
+          <pose>-0.05 0 0 0 1.5708 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <collision name="col_cylinder">
+          <pose>0 0 0.5 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.9</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+      <!-- pin joint for upper link, at origin of upper link -->
+      <joint name="pendulum" type="revolute">
+        <parent>base</parent>
+        <child>pendulum</child>
+        <physics>
+          <provide_feedback>true</provide_feedback>
+        </physics>
+        <axis>
+          <xyz>1.0 0 0</xyz>
+        </axis>
+      </joint>
+      <plugin name="my_ft"
+        filename="libgazebo_hrim_ft_sensor.so">
+        <ros>
+          <namespace>/demo</namespace>
+          <argument>~/out:=reading</argument>
+        </ros>
+        <update_rate>100</update_rate>
+        <joint_name>pendulum</joint_name>
+      </plugin>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
Couldn't implement as a sensor (inside a link) because of the current gazebo9 version not having the force_torque sensor type implemented (yet). [Current sensors](https://bitbucket.org/osrf/gazebo/src/f0ca9509eb416d86de2176863fb724ec094f7d0a/gazebo/msgs/msgs.cc?at=default&fileviewer=file-view-default#msgs.cc-1775)

Limited to joints of type:
  - revolute
  - prismatic
  - fixed

As the rest of joint types don't have the GetForceTorque method implemented (force/torque transformations for each joint type happen [here](https://bitbucket.org/osrf/gazebo/src/bd1cdea8fa3d71d6afcdaa83c9b01891d5f72e71/gazebo/physics/ode/ODEJoint.cc?at=default&fileviewer=file-view-default#ODEJoint.cc-651)).